### PR TITLE
fix: ensure seat arrows remain clickable above avatars

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -547,8 +547,15 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1;
     pointer-events: none;
+}
+
+#seats-container {
+    z-index: 10;
+}
+
+#avatars-container {
+    z-index: 1;
 }
 
 .seat {
@@ -582,6 +589,7 @@ body {
 
 .seat.occupied {
     cursor: default;
+    pointer-events: none;
 }
 
 .seat.occupied::after {


### PR DESCRIPTION
Fixes #29

## Summary
This PR fixes the issue where the enlarging effect on avatar hover overlaps with seating arrows on small screens, preventing affected seats from being chosen.

## Changes
- Modified `public/style.css`:
  - Set `#seats-container` z-index to 10 (higher than avatars)
  - Set `#avatars-container` z-index to 1
  - Added `pointer-events: none` to occupied seats to allow avatar hover effects to work properly

## How it works
By giving the seats container a higher z-index than the avatars container, seat arrows are always clickable. Occupied seats don't block mouse events (pointer-events: none), so the avatar hover enlarging effect still works when hovering over the center of an avatar.
